### PR TITLE
Fix deprecation crashes and update to current JAX/Orbax APIs

### DIFF
--- a/analysis/view_ppo_agent.py
+++ b/analysis/view_ppo_agent.py
@@ -9,11 +9,6 @@ import optax
 import yaml
 from craftax.environment_base.wrappers import AutoResetEnvWrapper
 from flax.training.train_state import TrainState
-from orbax.checkpoint import (
-    PyTreeCheckpointer,
-    CheckpointManagerOptions,
-    CheckpointManager,
-)
 import orbax.checkpoint as ocp
 
 from models.actor_critic import ActorCriticConv, ActorCritic
@@ -31,10 +26,10 @@ def main(args):
 
     config["NUM_ENVS"] = 1
 
-    orbax_checkpointer = PyTreeCheckpointer()
-    options = CheckpointManagerOptions(max_to_keep=1, create=True)
-    checkpoint_manager = CheckpointManager(
-        os.path.join(args.path, "policies"), orbax_checkpointer, options
+    options = ocp.CheckpointManagerOptions(max_to_keep=1)
+    checkpoint_manager = ocp.CheckpointManager(
+        os.path.join(args.path, "policies"),
+        options=options
     )
 
     is_classic = False
@@ -93,8 +88,11 @@ def main(args):
         tx=tx,
     )
 
+    abstract_train_state = jax.eval_shape(lambda: train_state)
+
     train_state = checkpoint_manager.restore(
-        config["TOTAL_TIMESTEPS"], items=train_state
+        config["TOTAL_TIMESTEPS"],
+        args=ocp.args.StandardRestore(abstract_train_state)
     )
 
     obs, env_state = env.reset(key=__rng)

--- a/models/actor_critic.py
+++ b/models/actor_critic.py
@@ -8,7 +8,7 @@ import distrax
 
 
 class ActorCriticConvSymbolicCraftax(nn.Module):
-    action_dim: Sequence[int]
+    action_dim: int
     map_obs_shape: Sequence[int]
     layer_width: int
 
@@ -81,7 +81,7 @@ class ActorCriticConvSymbolicCraftax(nn.Module):
 
 
 class ActorCriticConv(nn.Module):
-    action_dim: Sequence[int]
+    action_dim: int
     layer_width: int
     activation: str = "tanh"
 
@@ -127,7 +127,7 @@ class ActorCriticConv(nn.Module):
 
 
 class ActorCritic(nn.Module):
-    action_dim: Sequence[int]
+    action_dim: int
     layer_width: int
     activation: str = "tanh"
 
@@ -193,7 +193,7 @@ class ActorCritic(nn.Module):
 
 
 class ActorCriticWithEmbedding(nn.Module):
-    action_dim: Sequence[int]
+    action_dim: int
     layer_width: int
     activation: str = "tanh"
 

--- a/models/rnd.py
+++ b/models/rnd.py
@@ -2,7 +2,6 @@ import jax.numpy as jnp
 import flax.linen as nn
 import numpy as np
 from flax.linen.initializers import constant, orthogonal
-from typing import Sequence
 
 import distrax
 
@@ -29,7 +28,7 @@ class RNDNetwork(nn.Module):
 
 
 class ActorCriticRND(nn.Module):
-    action_dim: Sequence[int]
+    action_dim: int
     layer_width: int
     activation: str = "tanh"
 

--- a/ppo.py
+++ b/ppo.py
@@ -650,7 +650,7 @@ def run_ppo(config):
 
             with ocp.CheckpointManager(path, options=options) as checkpoint_manager:
                 checkpoint_manager.save(
-                    config["TOTAL_TIMESTEPS"],
+                    int(config["TOTAL_TIMESTEPS"]),
                     args=ocp.args.StandardSave(train_state)
                 )
 

--- a/ppo.py
+++ b/ppo.py
@@ -12,13 +12,8 @@ from craftax.craftax_env import make_craftax_env_from_name
 import wandb
 from typing import NamedTuple
 
-from flax.training import orbax_utils
 from flax.training.train_state import TrainState
-from orbax.checkpoint import (
-    PyTreeCheckpointer,
-    CheckpointManagerOptions,
-    CheckpointManager,
-)
+import orbax.checkpoint as ocp
 
 from logz.batch_logging import batch_log, create_log_dict
 from models.actor_critic import (
@@ -649,17 +644,17 @@ def run_ppo(config):
         def _save_network(rs_index, dir_name):
             train_states = out["runner_state"][rs_index]
             train_state = jax.tree.map(lambda x: x[0], train_states)
-            orbax_checkpointer = PyTreeCheckpointer()
-            options = CheckpointManagerOptions(max_to_keep=1, create=True)
+
             path = os.path.join(wandb.run.dir, dir_name)
-            checkpoint_manager = CheckpointManager(path, orbax_checkpointer, options)
+            options = ocp.CheckpointManagerOptions(max_to_keep=1)
+
+            with ocp.CheckpointManager(path, options=options) as checkpoint_manager:
+                checkpoint_manager.save(
+                    config["TOTAL_TIMESTEPS"],
+                    args=ocp.args.StandardSave(train_state)
+                )
+
             print(f"saved runner state to {path}")
-            save_args = orbax_utils.save_args_from_target(train_state)
-            checkpoint_manager.save(
-                config["TOTAL_TIMESTEPS"],
-                train_state,
-                save_kwargs={"save_args": save_args},
-            )
 
         if config["SAVE_POLICY"]:
             _save_network(0, "policies")

--- a/ppo_rnd.py
+++ b/ppo_rnd.py
@@ -599,7 +599,7 @@ def run_ppo(config):
 
             with ocp.CheckpointManager(path, options=options) as checkpoint_manager:
                 checkpoint_manager.save(
-                    config["TOTAL_TIMESTEPS"],
+                    int(config["TOTAL_TIMESTEPS"]),
                     args=ocp.args.StandardSave(train_state)
                 )
 

--- a/ppo_rnd.py
+++ b/ppo_rnd.py
@@ -12,13 +12,8 @@ from craftax.craftax_env import make_craftax_env_from_name
 import wandb
 from typing import NamedTuple
 
-from flax.training import orbax_utils
 from flax.training.train_state import TrainState
-from orbax.checkpoint import (
-    PyTreeCheckpointer,
-    CheckpointManagerOptions,
-    CheckpointManager,
-)
+import orbax.checkpoint as ocp
 
 from logz.batch_logging import batch_log, create_log_dict
 from wrappers import (
@@ -598,17 +593,17 @@ def run_ppo(config):
         def _save_network(rs_index, dir_name):
             train_states = out["runner_state"][rs_index]
             train_state = jax.tree.map(lambda x: x[0], train_states)
-            orbax_checkpointer = PyTreeCheckpointer()
-            options = CheckpointManagerOptions(max_to_keep=1, create=True)
+
             path = os.path.join(wandb.run.dir, dir_name)
-            checkpoint_manager = CheckpointManager(path, orbax_checkpointer, options)
+            options = ocp.CheckpointManagerOptions(max_to_keep=1)
+
+            with ocp.CheckpointManager(path, options=options) as checkpoint_manager:
+                checkpoint_manager.save(
+                    config["TOTAL_TIMESTEPS"],
+                    args=ocp.args.StandardSave(train_state)
+                )
+
             print(f"saved runner state to {path}")
-            save_args = orbax_utils.save_args_from_target(train_state)
-            checkpoint_manager.save(
-                config["TOTAL_TIMESTEPS"],
-                train_state,
-                save_kwargs={"save_args": save_args},
-            )
 
         if config["SAVE_POLICY"]:
             _save_network(0, "policies")

--- a/ppo_rnn.py
+++ b/ppo_rnn.py
@@ -18,7 +18,7 @@ from orbax.checkpoint import (
 
 import wandb
 from flax.linen.initializers import constant, orthogonal
-from typing import Sequence, NamedTuple, Dict
+from typing import NamedTuple, Dict
 from flax.training.train_state import TrainState
 import distrax
 import functools
@@ -66,7 +66,7 @@ class ScannedRNN(nn.Module):
 
 
 class ActorCriticRNN(nn.Module):
-    action_dim: Sequence[int]
+    action_dim: int
     config: Dict
 
     @nn.compact

--- a/ppo_rnn.py
+++ b/ppo_rnn.py
@@ -9,12 +9,7 @@ import numpy as np
 import optax
 import time
 
-from flax.training import orbax_utils
-from orbax.checkpoint import (
-    PyTreeCheckpointer,
-    CheckpointManagerOptions,
-    CheckpointManager,
-)
+import orbax.checkpoint as ocp
 
 import wandb
 from flax.linen.initializers import constant, orthogonal
@@ -476,17 +471,17 @@ def run_ppo(config):
         def _save_network(rs_index, dir_name):
             train_states = out["runner_state"][rs_index]
             train_state = jax.tree.map(lambda x: x[0], train_states)
-            orbax_checkpointer = PyTreeCheckpointer()
-            options = CheckpointManagerOptions(max_to_keep=1, create=True)
+
             path = os.path.join(wandb.run.dir, dir_name)
-            checkpoint_manager = CheckpointManager(path, orbax_checkpointer, options)
+            options = ocp.CheckpointManagerOptions(max_to_keep=1)
+
+            with ocp.CheckpointManager(path, options=options) as checkpoint_manager:
+                checkpoint_manager.save(
+                    config["TOTAL_TIMESTEPS"],
+                    args=ocp.args.StandardSave(train_state)
+                )
+
             print(f"saved runner state to {path}")
-            save_args = orbax_utils.save_args_from_target(train_state)
-            checkpoint_manager.save(
-                config["TOTAL_TIMESTEPS"],
-                train_state,
-                save_kwargs={"save_args": save_args},
-            )
 
         if config["SAVE_POLICY"]:
             _save_network(0, "policies")

--- a/ppo_rnn.py
+++ b/ppo_rnn.py
@@ -477,7 +477,7 @@ def run_ppo(config):
 
             with ocp.CheckpointManager(path, options=options) as checkpoint_manager:
                 checkpoint_manager.save(
-                    config["TOTAL_TIMESTEPS"],
+                    int(config["TOTAL_TIMESTEPS"]),
                     args=ocp.args.StandardSave(train_state)
                 )
 

--- a/wrappers.py
+++ b/wrappers.py
@@ -68,7 +68,7 @@ class AutoResetEnvWrapper(GymnaxWrapper):
 
         # Auto-reset environment based on termination
         def auto_reset(done, state_re, state_st, obs_re, obs_st):
-            state = jax.tree_map(
+            state = jax.tree.map(
                 lambda x, y: jax.lax.select(done, x, y), state_re, state_st
             )
             obs = jax.lax.select(done, obs_re, obs_st)
@@ -132,11 +132,11 @@ class OptimisticResetVecEnvWrapper(GymnaxWrapper):
         reset_indexes = reset_indexes.at[being_reset].set(jnp.arange(self.num_resets))
 
         obs_re = obs_re[reset_indexes]
-        state_re = jax.tree_map(lambda x: x[reset_indexes], state_re)
+        state_re = jax.tree.map(lambda x: x[reset_indexes], state_re)
 
         # Auto-reset environment based on termination
         def auto_reset(done, state_re, state_st, obs_re, obs_st):
-            state = jax.tree_map(
+            state = jax.tree.map(
                 lambda x, y: jax.lax.select(done, x, y), state_re, state_st
             )
             obs = jax.lax.select(done, obs_re, obs_st)


### PR DESCRIPTION
Replaces deprecated jax.tree_map with jax.tree.map, fixes num_actions type annotation from Sequence[int] to int, and migrates checkpoint saving/restoring to the current Orbax v1 API.